### PR TITLE
only run test-and-deploy test job when deploying to master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,10 @@ workflows:
       - test
   test-and-deploy:
     jobs:
-      - test
+      - test:
+          filters:
+            branches:
+              only: master
       - deploy:
           requires:
             - test


### PR DESCRIPTION
circleci was running tests from two different workflows. seems that circleci does not support filtering workflows by branch, only filtering jobs within the workflow. so i added the filter to the test job in the test-and-deploy workflow.