### PR TITLE
remove mysqld command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,6 @@ jobs:
     docker:
       - image: circleci/node:7.10
       - image: circleci/mysql:5.6.39
-        command: [mysqld]
     environment:
       db_name: "circle_test"
       db_user: "root"


### PR DESCRIPTION
looks like it works without it! mysql is run already on the circle container as seen here:

![screen shot 2018-04-27 at 4 07 06 pm](https://user-images.githubusercontent.com/22226447/39388495-2f8a87d2-4a35-11e8-8d7a-5abc42564fbb.png)
